### PR TITLE
feat: Add ts def for extra iss stats

### DIFF
--- a/src/feature/map/defs/issStats.ts
+++ b/src/feature/map/defs/issStats.ts
@@ -1,0 +1,16 @@
+export interface ISSStats {
+    "name": string,
+    "id": number,
+    "latitude": number,
+    "longitude": number,
+    "altitude": number,
+    "velocity": number,
+    "visibility": 'daylight' | 'eclipsed',
+    "footprint": number,
+    "timestamp": Date,
+    "daynum": number,
+    "solar_lat": number,
+    "solar_lon": number,
+    "units": 'kilometers' | 'miles'
+  }
+  

--- a/src/feature/map/utils/iss/getCoords.ts
+++ b/src/feature/map/utils/iss/getCoords.ts
@@ -1,15 +1,11 @@
 import { Coordinates } from '../../defs/coordinates';
-
-interface IssPosition {
-    longitude: string;
-    latitude: string;
-  }
+import { ISSStats } from '../../defs/issStats';
 
   
-  export function getLocationCoordinates(res: IssPosition): Coordinates {    
+  export function getLocationCoordinates(res: ISSStats): Coordinates {    
     return {
-      longitude: parseInt(res.longitude, 10),
-      latitude: parseInt(res.latitude, 10)
+      longitude: res.longitude,
+      latitude: res.latitude
      }
   }
   


### PR DESCRIPTION
As we switched APIs to get around https, the new API provides extra data, it would be nice to consume this and present it.

- [x] Add ISS State TS def
- [ ] Add new element to show title + data
- [ ] Use new element to show Lat
- [ ] To show Lon
- [ ] To show Speed
- [ ] To show nearest capital city
- [ ] Switch from flex to grid for layout
- [ ] Keep mobile first

Nice to have
- [ ] Have some kind of counter/spinner for the value changes - try to do only in CSS
- [ ] Add a line to track the history of the ISS on the map - maybe a dotted line
- [ ] Store the stats for each dot
- [ ] Present stats as a tooltip